### PR TITLE
Added support for priority on cart creation

### DIFF
--- a/lib/Nitesi/Cart.pm
+++ b/lib/Nitesi/Cart.pm
@@ -237,6 +237,16 @@ sub add {
 	$item{quantity} = 1;
     }
 
+    if (exists $item{priority} && defined $item{priority}) {
+        unless ($item{priority} =~ /^\d+$/) {
+            $self->{error} = "Item $item{sku} added with invalid priority.";
+            return;
+        }
+    }
+    else {
+        $item{priority} = 0;
+    }
+
     unless (exists $item{price} && defined $item{price}
 	    && $item{price} =~ /^(\d+)(\.\d+)?$/ && $item{price} > 0) {
 	$self->{error} = "Item $item{sku} added with invalid price.";

--- a/t/priority.t
+++ b/t/priority.t
@@ -1,0 +1,40 @@
+#! perl
+#
+# Tests for Nitesi::Cart priority
+
+use strict;
+use warnings;
+
+use Test::More tests => 6;
+use Nitesi::Cart;
+use Data::Dumper;
+
+my $cart = Nitesi::Cart->new();
+my $ret = $cart->add({ sku => "123",
+                       name => 'test',
+                       price => '15',
+                       quantity => 1 });
+
+# print Dumper($cart->items);
+
+ok(exists $cart->items->[0]->{priority}, "priority found"),
+is($cart->items->[0]->{priority}, 0, "default priority == 0");
+
+$ret = $cart->add({ sku => "123x",
+                    name => 'testx',
+                    price => '15.2',
+                    quantity => 2,
+                    priority => 3,
+                  });
+
+is($cart->items->[0]->{priority}, 0);
+is($cart->items->[1]->{priority}, 3, "Priority added with 3");
+
+$ret = $cart->add({ sku => "123x",
+                    name => 'testx',
+                    price => '15.2',
+                    quantity => 2,
+                    priority => 'abc',
+                  });
+ok(!$ret);
+ok($cart->error);


### PR DESCRIPTION
Set the priority of the added item to 0 if not specified. 0 was already the default for the cart_products.priority
